### PR TITLE
real github click fix

### DIFF
--- a/layout/css/header-footer.css
+++ b/layout/css/header-footer.css
@@ -51,11 +51,12 @@ footer:after {
      height: 0;
      }
 
-#github-link img {
+#github-logo{
   max-height:40px;
   float:left;
   width:40px;
   margin:0 10px 15px 0;
+  pointer-events: none;
 }
 #github-link {
   display:inline-block;

--- a/layout/templates/footer.mustache
+++ b/layout/templates/footer.mustache
@@ -2,7 +2,7 @@
   <div class="footerContentAligner">
     <a class="hotfix" href="https://github.com/USGS-VIZLAB/water-use" target="_blank" onclick="ga('send', 'event', 'outbound', 'clicked on repo')">
       <div id="github-link">
-      	<img src="images/github.svg" alt="github icon"/>
+      	{{{github}}}
     	  <p>The code used here is available on github</p>
       </div>
      </a>


### PR DESCRIPTION
Did a little digging and found http://stackoverflow.com/questions/11374059/make-an-html-svg-object-also-a-clickable-link the third answer with 113 up votes is what worked for me. Something to do with ad blocker? But this way we remove the hard code image and get the svg we want. @jiwalker-usgs 