### PR TITLE
freshwater instead

### DIFF
--- a/viz.yaml
+++ b/viz.yaml
@@ -143,7 +143,7 @@ process:
     reader: rds
     depends:
       rawdata: wu_data_15
-    orig_names: ["TO-Wtotl", "PT-Wtotl", "PS-Wtotl", "IR-WFrTo", "IN-Wtotl"]
+    orig_names: ["TO-Wtotl", "PT-WFrTo", "PS-WFrTo", "IR-WFrTo", "IN-WFrTo"]
     new_names: ["total", "thermoelectric", "publicsupply", "irrigation", "industrial"]
     processor: simplify_wu_data
     scripts: [scripts/process/simplify_2015_wu_data.R]


### PR DESCRIPTION
Using appropriate freshwater values.

This still needs some work to be perfect. Industrial needs to be `IR-WFrTo` + `MI-WFrTo` but right now it's just `IR-WFrTo`, and total shouldn't be `TO-Wtotl` but instead the sum of the categories we are using in the map (`PT-WFrTo + IR-WFrTo + PS-WFrTo + IN-WFrTo + MI-WFrTo`). This took some more work than just editing the columns being used, so I didn't include it here.